### PR TITLE
Fix docker-compose with pm2 usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This command will start a Kuzzle stack with this plugin enabled. To make develop
 You can choose to work on the Kuzzle development branch by defining the following environment variables before launching `docker-compose`:
 
 ```bash
-$ export KUZZLE_DOCKER_TAG=develop
+$ export KUZZLE_DOCKER_TAG=1.2.13
 $ docker-compose -f docker/docker-compose.yml up
 ```
 
@@ -70,6 +70,6 @@ $ docker-compose -f docker/docker-compose.yml up
   * Use semver notation to born Kuzzle version this plugins supports
   * - if set, and installation requirement is not meet, an error will be thrown and Kuzzle will not start
   */
-  "kuzzleVersion": "^1.1.x"
+  "kuzzleVersion": "^1.2.x"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -38,14 +38,11 @@ This command will start a Kuzzle stack with this plugin enabled. To make develop
 You can choose to work on the Kuzzle development branch by defining the following environment variables before launching `docker-compose`:
 
 ```bash
-$ export KUZZLE_DOCKER_TAG=:develop
-$ export PROXY_DOCKER_TAG=:develop
+$ export KUZZLE_DOCKER_TAG=develop
 $ docker-compose -f docker/docker-compose.yml up
 ```
 
 These environment variables enable you to specify any existing build tag available on [Docker Hub](https://hub.docker.com/r/kuzzleio/kuzzle/tags/).
-
-**Note** do not forget the `:` before the tag.
 
 #### Customizing the plugin instance name
 
@@ -73,19 +70,6 @@ $ docker-compose -f docker/docker-compose.yml up
   * Use semver notation to born Kuzzle version this plugins supports
   * - if set, and installation requirement is not meet, an error will be thrown and Kuzzle will not start
   */
-  "kuzzleVersion": "^1.1.x",
-
-  /**
-   * Define if this plugin supports worker plugins (multi-threaded)
-   * Setting this to true allows users to set "threads" configuration
-   *
-   * /!\ warning: Threaded plugins will not be able to access:
-   *                - authentication strategies
-   *                - pipes events
-   *                - custom controllers
-   *
-   * @type {Boolean}
-   */
-  "threadable": true
+  "kuzzleVersion": "^1.1.x"
 }
 ```

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   kuzzle:
-    image: kuzzleio/kuzzle
+    image: kuzzleio/kuzzle:${KUZZLE_DOCKER_TAG:-latest}
     command: /run-dev.sh
     volumes:
       - "./run-dev.sh:/run-dev.sh"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,28 +1,24 @@
-version: '2.1'
+version: '3'
 
 services:
-  proxy:
-    image: kuzzleio/proxy${PROXY_DOCKER_TAG}
-    ports:
-      - "7512:7512"
-
   kuzzle:
-    image: kuzzleio/kuzzle${KUZZLE_DOCKER_TAG}
+    image: kuzzleio/kuzzle
+    command: /run-dev.sh
     volumes:
+      - "./run-dev.sh:/run-dev.sh"
       - "./pm2.json:/config/pm2.json"
       - "..:/var/app/plugins/enabled/${PLUGIN_NAME:-kuzzle-core-plugin-boilerplate}"
     depends_on:
-      - proxy
       - redis
       - elasticsearch
     ports:
       - "8080:8080"
       - "9229:9229"
+      - "7512:7512"
     environment:
-      - kuzzle_services__db__host=elasticsearch
+      - kuzzle_services__db__client__host=http://elasticsearch:9200
       - kuzzle_services__internalCache__node__host=redis
       - kuzzle_services__memoryStorage__node__host=redis
-      - kuzzle_services__proxyBroker__host=proxy
       - NODE_ENV=development
       - DEBUG=kuzzle:plugins
 

--- a/docker/run-dev.sh
+++ b/docker/run-dev.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+set -e
+
+log () {
+  echo "[$(date --rfc-3339 seconds)] - $1"
+}
+
+elastic_host=${kuzzle_services__db__client__host:-http://elasticsearch:9200}
+
+log "Waiting for elasticsearch"
+while ! curl -f -s -o /dev/null "$elastic_host"
+do
+    log "Still trying to connect to $elastic_host"
+    sleep 1
+done
+# create a tmp index just to force the shards to init
+curl -XPUT -s -o /dev/null "$elastic_host/%25___tmp"
+log "Elasticsearch is up. Waiting for shards..."
+E=$(curl -s "$elastic_host/_cluster/health?wait_for_status=yellow&wait_for_active_shards=1&timeout=60s")
+curl -XDELETE -s -o /dev/null "$elastic_host/%25___tmp"
+
+if ! (echo ${E} | grep -E '"status":"(yellow|green)"' > /dev/null); then
+    log "Could not connect to elasticsearch in time. Aborting..."
+    exit 1
+fi
+
+log "Starting Kuzzle..."
+
+pm2 start /config/pm2.json
+pm2 logs --lines 2

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,8 +17,6 @@ class CorePlugin {
    * Workflow is:
    *  - Kuzzle loads plugins in <kuzzle install dir>/plugins/enabled/* and try to instanciate them, also configuration and manifest.json file are read.
    *     /!\ Misconfiguration will stop starting sequance of kuzzle
-   *  - Kuzzle tries to initialiate worker plugins in spawned process though pm2
-   *  - "init" function is called for both worker and regular plugins.
    *  - Plugin manager registers all plugin features into kuzzle (register hooks/pipes, load custom configuration, check for authentication strategies, ...)
    *     /!\ Misconfiguration will stop starting sequance of kuzzle
    *
@@ -133,7 +131,7 @@ class CorePlugin {
      */
     this.routes = [
       {verb: 'get', url: '/say-something/:property', controller: 'myNewController', action: 'myNewAction'},
-      {verb: 'get', url: '/say-something', controller: 'myNewController', action: 'myNewAction'}
+      {verb: 'post', url: '/say-something', controller: 'myNewController', action: 'myNewAction'}
     ];
 
     /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,7 +18,7 @@ class CorePlugin {
    *  - Kuzzle loads plugins in <kuzzle install dir>/plugins/enabled/* and try to instanciate them, also configuration and manifest.json file are read.
    *     /!\ Misconfiguration will stop starting sequance of kuzzle
    *  - Kuzzle tries to initialiate worker plugins in spawned process though pm2
-   *  - "init" function is called for both woker and regular plugins.
+   *  - "init" function is called for both worker and regular plugins.
    *  - Plugin manager registers all plugin features into kuzzle (register hooks/pipes, load custom configuration, check for authentication strategies, ...)
    *     /!\ Misconfiguration will stop starting sequance of kuzzle
    *

--- a/lib/index.js
+++ b/lib/index.js
@@ -133,7 +133,7 @@ class CorePlugin {
      */
     this.routes = [
       {verb: 'get', url: '/say-something/:property', controller: 'myNewController', action: 'myNewAction'},
-      {verb: 'post', url: '/say-something', controller: 'myNewController', action: 'myNewAction'}
+      {verb: 'get', url: '/say-something', controller: 'myNewController', action: 'myNewAction'}
     ];
 
     /**


### PR DESCRIPTION
## What does this PR do ?

The docker-compose stack provided with this repository was outdated.  

This PR update docker-compose stack : 
  - remove the proxy container
  - fix env variables
  - add PM2 support

### How should this be manually tested?

  - Step 1 : Get the branch: `git fetch origin fix-docker-compose && git checkout fix-docker-compose`
  - Step 2 : Run the docker compose stack: `docker-compose -f docker/docker-compose.yml up`
  - Step 3 : Edit `lib/index.js`, Kuzzle should automatically reload
  ...

### Other changes

 - typo
 - remove section about threadable plugin in README