### PR TITLE
Bind node inspector on 0.0.0.0

### DIFF
--- a/docker/pm2.json
+++ b/docker/pm2.json
@@ -3,7 +3,7 @@
     "name": "KuzzleServer",
     "script": "bin/kuzzle",
     "args": ["start"],
-    "node_args": "--inspect",
+    "node_args": "--inspect=0.0.0.0:9229",
     "watch": ["plugins/enabled"],
     "ignore_watch" : ["node_modules", "plugins/enabled/**/.git", "plugins/enabled/**/features/*"]
   }]


### PR DESCRIPTION
## What does this PR do ?

This PR bind node inspector on `0.0.0.0`. This was the default behaviour with node6 but not anymore with node8.