### PR TITLE
Use plugin-dev image

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,13 +2,19 @@ version: '3'
 
 services:
   kuzzle:
-    image: kuzzleio/development:${KUZZLE_DOCKER_TAG:-latest}
+    image: kuzzleio/plugin-dev:${KUZZLE_DOCKER_TAG:-latest}
     command: /run-dev.sh
     volumes:
       - "./run-dev.sh:/run-dev.sh"
       - "./install-plugins.sh:/install-plugins.sh"
       - "./pm2.json:/config/pm2.json"
       - "..:/var/app/plugins/enabled/${PLUGIN_NAME:-kuzzle-core-plugin-boilerplate}"
+    cap_add:
+      - SYS_PTRACE
+    ulimits:
+      nofile: 65536
+    sysctls:
+      - net.core.somaxconn=8192
     depends_on:
       - redis
       - elasticsearch
@@ -26,11 +32,9 @@ services:
     image: redis:3.2
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:5.4.1
+    image: kuzzleio/elasticsearch:5.4.1
+    ulimits:
+      nofile: 65536
     environment:
       - cluster.name=kuzzle
-      # disable xpack
-      - xpack.security.enabled=false
-      - xpack.monitoring.enabled=false
-      - xpack.graph.enabled=false
-      - xpack.watcher.enabled=false
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"


### PR DESCRIPTION
## What does this PR do ?

This PR replace the obsolete `development` image by `plugin-dev`.

### How should this be manually tested?

  - Step 1 : Run a Kuzzle stack: `docker-compose -f docker/docker-compose.yml up`

### Other changes

  - update `docker-compose.yml` options for Kuzzle service
  - use `kuzzleio/elasticsearch` image
